### PR TITLE
Fix ports forwarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,22 +19,19 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
 	"forwardPorts": [
-		8069,
-		8072
+		8069
 	],
 	"portsAttributes": {
 		"8069": {
 			"label": "Odoo Web",
 			"onAutoForward": "silent"
-		},
-		"8072": {
-			"label": "Odoo Longpolling",
-			"onAutoForward": "silent"
 		}
 	},
 	"otherPortsAttributes": {
 		"onAutoForward": "ignore"
-	}
+	},
+	
+	"postCreateCommand": "odoo --config /etc/odoo/odoo.conf -d odoo_SGE -i base --stop-after-init"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,25 @@
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	"forwardPorts": [
+		8069,
+		8072
+	],
+	"portsAttributes": {
+		"8069": {
+			"label": "Odoo Web",
+			"onAutoForward": "silent"
+		},
+		"8072": {
+			"label": "Odoo Longpolling",
+			"onAutoForward": "silent"
+		}
+	},
+	"otherPortsAttributes": {
+		"onAutoForward": "ignore"
+	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,12 +15,14 @@ services:
       # Update this to wherever you want VS Code to mount the folder of your project
       - ..:/workspaces:cached
 
+    command: >
+      bash -c "odoo --config /etc/odoo/odoo.conf &
+               sleep infinity"
+
+    user: root
+
     # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
     # cap_add:
     #   - SYS_PTRACE
     # security_opt:
-    #   - seccomp:unconfined
-
-    # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity
- 
+    #   - seccomp:unconfined 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Proyecto de Odoo 18 con PostgreSQL 15 usando Docker Compose para un entorno de d
 - [Docker](https://docs.docker.com/get-docker/) instalado (versión 20.10 o superior)
 - [Docker Compose](https://docs.docker.com/compose/install/) instalado (versión 2.0 o superior)
 - Al menos 4GB de RAM disponible
-- Puertos 8069 y 8072 libres en tu máquina
+- Puerto 8069 libre en tu máquina
 
 ## 🚀 Instalación y configuración
 
@@ -49,8 +49,8 @@ db_host = db
 db_port = 5432
 db_user = odoo
 db_password = odoo
-workers = 2
-max_cron_threads = 1
+db_name = odoo_SGE
+workers = 0
 ```
 
 > ⚠️ **IMPORTANTE**: Cambia `admin_passwd` por una contraseña segura antes de usar en producción.
@@ -61,7 +61,7 @@ Para producción, edita el archivo `docker-compose.yml` y cambia las contraseña
 
 ```yaml
 environment:
-  - POSTGRES_PASSWORD=TU_PASSWORD_SEGURA  # Cambiar aquí
+  - POSTGRES_PASSWORD=TU_PASSWORD_SEGURA
 ```
 
 Y actualiza también en `odoo.conf`:
@@ -93,7 +93,7 @@ Deberías ver algo como:
 ```
 NAME                COMMAND                  SERVICE   STATUS          PORTS
 project-db-1        "docker-entrypoint.s…"   db        Up (healthy)    5432/tcp
-project-web-1       "/entrypoint.sh odoo"    web       Up              0.0.0.0:8069->8069/tcp, 0.0.0.0:8072->8072/tcp
+project-web-1       "/entrypoint.sh odoo"    web       Up              0.0.0.0:8069->8069/tcp
 ```
 
 ### Ver los logs
@@ -111,21 +111,19 @@ docker-compose logs -f db
 
 ## 🌐 Acceder a Odoo
 
-Una vez levantado, accede a Odoo desde tu navegador:
+Una vez levantado, accede a Odoo desde tu navegador en:
 
 ```
 http://localhost:8069
 ```
 
-En la primera ejecución:
-1. Se mostrará la pantalla de creación de base de datos
-2. Completa los siguientes campos:
-   - **Master Password**: La que configuraste en `admin_passwd` del `odoo.conf`
-   - **Database Name**: Nombre de tu base de datos (ej: `mi_empresa`)
-   - **Email**: Tu email de administrador
-   - **Password**: Contraseña para el usuario administrador
-   - **Language**: Español (o el idioma que prefieras)
-   - **Country**: España (o tu país)
+En la primera ejecución se mostrará la pantalla de creación de base de datos. Completa los siguientes campos:
+- **Master Password**: La que configuraste en `admin_passwd` del `odoo.conf`
+- **Database Name**: Nombre de tu base de datos (ej: `odoo_SGE`)
+- **Email**: Tu email de administrador
+- **Password**: Contraseña para el usuario administrador
+- **Language**: Español (o el idioma que prefieras)
+- **Country**: España (o tu país)
 
 ## 🛠️ Comandos útiles
 
@@ -236,7 +234,7 @@ docker-compose ps
 
 ```bash
 docker-compose down
-sudo rm -rf postgresql odoo-web-data
+rm -rf postgresql odoo-web-data
 mkdir -p addons postgresql odoo-web-data
 docker-compose up -d
 ```
@@ -288,36 +286,40 @@ Este proyecto incluye configuración para [Dev Containers](https://containers.de
 
 La configuración en `.devcontainer/` extiende el `docker-compose.yml` principal del proyecto:
 
-- **`devcontainer.json`** apunta al servicio `web` (Odoo) como contenedor de trabajo y monta el proyecto en `/workspaces` dentro del contenedor.
+- **`devcontainer.json`** apunta al servicio `web` (Odoo) como contenedor de trabajo, monta el proyecto en `/workspaces` dentro del contenedor, e inicializa la base de datos automáticamente la primera vez.
 - **`.devcontainer/docker-compose.yml`** sobreescribe el comando por defecto con `sleep infinity` para mantener el contenedor activo mientras VS Code está conectado, sin interferir con el proceso de Odoo.
 
 ### Pasos para usarlo
 
-1. Asegúrate de tener los contenedores levantados o simplemente abre el proyecto en VS Code.
+1. Abre el proyecto en VS Code.
 
-2. Abre la paleta de comandos (`Ctrl+Shift+P` / `Cmd+Shift+P`) y ejecuta:
+2. Abre la paleta de comandos (`Ctrl+Shift+P`) y ejecuta:
 
    ```
    Dev Containers: Reopen in Container
    ```
 
-3. VS Code se reconectará al contenedor `web` de Odoo. Tendrás acceso directo al sistema de archivos del contenedor en `/workspaces`.
+3. VS Code construirá el entorno e inicializará automáticamente la base de datos `odoo_SGE` la primera vez.
+
+4. Accede a Odoo en `http://localhost:8069` con las credenciales por defecto:
+   - **Usuario**: `admin`
+   - **Contraseña**: `admin`
 
 ### Notas importantes
 
 - Los cambios en `addons/` se reflejan en tiempo real gracias al volumen montado.
 - El contenedor de base de datos (`db`) sigue corriendo con normalidad; solo el servicio `web` se adapta para el modo desarrollo.
-- Si necesitas ejecutar comandos de Odoo manualmente (como actualizar módulos), puedes hacerlo desde la terminal integrada de VS Code:
+- La base de datos solo se inicializa la primera vez. En reinicios posteriores del devcontainer los datos persisten.
+- Si necesitas actualizar un módulo manualmente, puedes hacerlo desde la terminal integrada de VS Code:
 
   ```bash
-  odoo --update=nombre_modulo --database=mi_empresa --stop-after-init
+  odoo --config /etc/odoo/odoo.conf -d odoo_SGE --update=nombre_modulo --stop-after-init
   ```
 
-- Para volver al modo normal (sin Dev Container), usa simplemente `docker-compose up -d` desde tu terminal.
+- Para volver al modo normal (sin Dev Container), usa simplemente `docker-compose up -d` desde tu terminal y crea la BD desde `http://localhost:8069/web/database/manager`.
 
 ## 📚 Recursos adicionales
 
 - [Documentación oficial de Odoo](https://www.odoo.com/documentation/18.0/)
 - [Odoo en Docker Hub](https://hub.docker.com/_/odoo)
 - [PostgreSQL en Docker Hub](https://hub.docker.com/_/postgres)
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       db:
         condition: service_healthy # Solo levantamos el servidor web si la base de datos esta healthy
     ports:
-      - "8069:8069"
-      - "8072:8072"  # Puerto para longpolling/live chat
+      - "0.0.0.0:8069:8069"
+      - "0.0.0.0:8072:8072"
     volumes:
       - ./addons:/mnt/extra-addons
       - ./odoo.conf:/etc/odoo/odoo.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
         condition: service_healthy # Solo levantamos el servidor web si la base de datos esta healthy
     ports:
       - "0.0.0.0:8069:8069"
-      - "0.0.0.0:8072:8072"
     volumes:
       - ./addons:/mnt/extra-addons
       - ./odoo.conf:/etc/odoo/odoo.conf

--- a/odoo.conf
+++ b/odoo.conf
@@ -5,5 +5,5 @@ db_host = db
 db_port = 5432
 db_user = odoo
 db_password = odoo
-workers = 2
-max_cron_threads = 1
+db_name = odoo_SGE
+workers = 0


### PR DESCRIPTION
This pull request updates the Odoo 18 + PostgreSQL 15 Docker Compose environment to simplify port usage, improve Dev Container integration, and streamline database initialization for development. The main changes focus on exposing only the necessary port, automating the initial database setup in development containers, and clarifying documentation and configuration for a smoother developer experience.

**Dev Container and Docker Compose improvements:**

* The `.devcontainer/devcontainer.json` now auto-forwards port 8069 (Odoo Web), labels it for clarity, and runs a `postCreateCommand` to initialize the `odoo_SGE` database automatically on first launch.
* The `.devcontainer/docker-compose.yml` file starts Odoo in the background and keeps the container alive for development, running as `root` for compatibility.

**Port and service exposure simplification:**

* The main `docker-compose.yml` and documentation now only expose port 8069 (removing 8072), reducing conflicts and simplifying access. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L25-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96)

**Configuration and initialization changes:**

* The default `odoo.conf` and related documentation now set `db_name = odoo_SGE` and `workers = 0` for local dev, matching the automated Dev Container setup. [[1]](diffhunk://#diff-a13f66a225151bb93dd93715ec2f26c3c0aea6e9d0052051dd22e9cb2139cc29L8-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R53)
* The Dev Container workflow is clarified in the `README.md`, including new instructions for automatic database creation and default credentials, and improved guidance for updating modules and switching between dev and normal modes.

**Documentation cleanup and usability:**

* Instructions and examples in `README.md` are updated for clarity, including removal of unnecessary `sudo`, improved first-run steps, and consistent references to the default database and credentials. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L239-R237) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R122) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R64)

These changes make the development setup more predictable and user-friendly, especially when using VS Code Dev Containers.