### PR TITLE
Fix/docker odoo filestore persistence

### DIFF
--- a/.github/workflows/odoo-ci.yml
+++ b/.github/workflows/odoo-ci.yml
@@ -1,17 +1,13 @@
 name: Odoo CI
-
 on:
   push:
     branches: [main]
   pull_request:
-
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   odoo:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -19,69 +15,81 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Odoo image
-        run: docker compose build
-
       - name: Start Odoo stack
         run: docker compose up -d
 
-      - name: Wait for Odoo to start
+      - name: Wait for Odoo to be ready
         run: |
           echo "Waiting for Odoo..."
           for i in {1..30}; do
-            if curl -s http://localhost:8069/web/login > /dev/null; then
+            if curl -sf http://localhost:8069/web/login > /dev/null; then
               echo "Odoo is up"
               exit 0
             fi
+            echo "Attempt $i/30..."
             sleep 5
           done
           echo "Odoo did not start in time"
           docker compose logs
           exit 1
 
+      - name: Initialize Odoo database
+        run: |
+          # Creamos la BD 'ci_test' para que Odoo genere el filestore
+          CONTAINER=$(docker compose ps -q web)
+          docker exec "$CONTAINER" odoo \
+            --config /etc/odoo/odoo.conf \
+            --database ci_test \
+            --init base \
+            --stop-after-init \
+            --without-demo all
+
       - name: Assert filestore path
         run: |
-          set +e
-          CONTAINER=$(docker ps \
-            --filter "label=com.docker.compose.service=web" \
-            --format "{{.ID}}")
-          set -e
+          CONTAINER=$(docker compose ps -q web)
 
           if [ -z "$CONTAINER" ]; then
-            echo "ERROR: Odoo container not found"
+            echo "ERROR: Odoo web container not found"
             docker compose ps
             docker compose logs
             exit 1
           fi
-      
-          docker exec "$CONTAINER" test -d /var/lib/odoo/filestore
-          docker exec "$CONTAINER" test ! -d /root/.local/share/Odoo
 
-      # Simulate a rebuild by taking down the stack and bringing it back up
+          echo "Container: $CONTAINER"
+
+          # Verificar que data_dir está montado correctamente
+          docker exec "$CONTAINER" test -d /var/lib/odoo \
+            && echo "OK: /var/lib/odoo exists"
+
+          # Verificar que el filestore se creó tras init
+          docker exec "$CONTAINER" test -d /var/lib/odoo/filestore \
+            && echo "OK: filestore exists"
+
+          # Verificar que NO se usa el path por defecto (sin config)
+          docker exec "$CONTAINER" test ! -d /root/.local/share/Odoo \
+            && echo "OK: default path not used"
+
       - name: Rebuild test (down -> up)
         run: |
           docker compose down
           docker compose up -d
-
           for i in {1..20}; do
-            if curl -s http://localhost:8069/web/login > /dev/null; then
+            if curl -sf http://localhost:8069/web/login > /dev/null; then
               echo "Odoo is up after rebuild"
               exit 0
             fi
+            echo "Attempt $i/20..."
             sleep 5
           done
-
           echo "Odoo did not recover after rebuild"
           docker compose logs
           exit 1
 
       - name: Final filestore check
         run: |
-          CONTAINER=$(docker ps \
-            --filter "label=com.docker.compose.service=web" \
-            --format "{{.ID}}")
-
-          docker exec "$CONTAINER" test -d /var/lib/odoo/filestore
+          CONTAINER=$(docker compose ps -q web)
+          docker exec "$CONTAINER" test -d /var/lib/odoo/filestore \
+            && echo "OK: filestore persisted after rebuild"
 
       - name: Odoo logs (on failure)
         if: failure()

--- a/.github/workflows/odoo-ci.yml
+++ b/.github/workflows/odoo-ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   odoo:
     runs-on: ubuntu-latest
@@ -33,13 +36,50 @@ jobs:
             sleep 5
           done
           echo "Odoo did not start in time"
+          docker compose logs
           exit 1
 
       - name: Assert filestore path
         run: |
-          CONTAINER=$(docker compose ps -q web)
+          CONTAINER=$(docker ps \
+            --filter "label=com.docker.compose.service=web" \
+            --format "{{.ID}}")
+
+          if [ -z "$CONTAINER" ]; then
+            echo "ERROR: Odoo container not found"
+            docker compose ps
+            docker compose logs
+            exit 1
+          fi
+
           docker exec "$CONTAINER" test -d /var/lib/odoo/filestore
           docker exec "$CONTAINER" test ! -d /root/.local/share/Odoo
+
+      # Simulate a rebuild by taking down the stack and bringing it back up
+      - name: Rebuild test (down -> up)
+        run: |
+          docker compose down
+          docker compose up -d
+
+          for i in {1..20}; do
+            if curl -s http://localhost:8069/web/login > /dev/null; then
+              echo "Odoo is up after rebuild"
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "Odoo did not recover after rebuild"
+          docker compose logs
+          exit 1
+
+      - name: Final filestore check
+        run: |
+          CONTAINER=$(docker ps \
+            --filter "label=com.docker.compose.service=web" \
+            --format "{{.ID}}")
+
+          docker exec "$CONTAINER" test -d /var/lib/odoo/filestore
 
       - name: Odoo logs (on failure)
         if: failure()

--- a/.github/workflows/odoo-ci.yml
+++ b/.github/workflows/odoo-ci.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  
 jobs:
   odoo:
     runs-on: ubuntu-latest

--- a/.github/workflows/odoo-ci.yml
+++ b/.github/workflows/odoo-ci.yml
@@ -1,0 +1,46 @@
+name: Odoo CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  odoo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Odoo image
+        run: docker compose build
+
+      - name: Start Odoo stack
+        run: docker compose up -d
+
+      - name: Wait for Odoo to start
+        run: |
+          echo "Waiting for Odoo..."
+          for i in {1..30}; do
+            if curl -s http://localhost:8069/web/login > /dev/null; then
+              echo "Odoo is up"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Odoo did not start in time"
+          exit 1
+
+      - name: Assert filestore path
+        run: |
+          CONTAINER=$(docker compose ps -q web)
+          docker exec "$CONTAINER" test -d /var/lib/odoo/filestore
+          docker exec "$CONTAINER" test ! -d /root/.local/share/Odoo
+
+      - name: Odoo logs (on failure)
+        if: failure()
+        run: docker compose logs

--- a/.github/workflows/odoo-ci.yml
+++ b/.github/workflows/odoo-ci.yml
@@ -41,9 +41,11 @@ jobs:
 
       - name: Assert filestore path
         run: |
+          set +e
           CONTAINER=$(docker ps \
             --filter "label=com.docker.compose.service=web" \
             --format "{{.ID}}")
+          set -e
 
           if [ -z "$CONTAINER" ]; then
             echo "ERROR: Odoo container not found"
@@ -51,7 +53,7 @@ jobs:
             docker compose logs
             exit 1
           fi
-
+      
           docker exec "$CONTAINER" test -d /var/lib/odoo/filestore
           docker exec "$CONTAINER" test ! -d /root/.local/share/Odoo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,13 @@ services:
     volumes:
       - ./addons:/mnt/extra-addons          # bind mount (necesario para desarrollo de modulos)
       - ./odoo.conf:/etc/odoo/odoo.conf     # bind mount para sobrrescribir config
-      - web-data:/var/lib/odoo              # named volume
+      - odoo-data:/var/lib/odoo             # named volume
     environment:
       - HOST=db
       - USER=odoo
       - PASSWORD=odoo
     restart: unless-stopped
 
-volumes:          # ← declaración obligatoria al final
+volumes:          
   db-data:
-  web-data:
+  odoo-data:

--- a/odoo.conf
+++ b/odoo.conf
@@ -1,11 +1,17 @@
 [options]
+data_dir = /var/lib/odoo
+
 addons_path = /usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons
-admin_passwd = admin123
+
 db_host = db
 db_port = 5432
 db_user = odoo
 db_password = odoo
+
+admin_passwd = admin123
+
 workers = 0
 proxy_mode = False
+
 web.base.url = http://localhost:8069
 web.base.url.freeze = True


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for continuous integration (CI) of the Odoo stack, standardizes the naming of the persistent data volume, and clarifies the Odoo configuration file. The main focus is on automating the build and validation of the Odoo Docker stack on each push and pull request, improving reliability and consistency in development.

**CI/CD Automation:**

* Added a new GitHub Actions workflow `.github/workflows/odoo-ci.yml` to automatically build the Odoo Docker image, start the stack, check Odoo startup, and validate filestore paths on every push and pull request. This ensures the stack is working as expected and that the filestore is correctly set up.

**Docker Compose and Volume Naming:**

* Renamed the persistent data volume from `web-data` to `odoo-data` in `docker-compose.yml` for clarity and consistency, and updated its declaration in the `volumes` section.

**Configuration File Improvements:**

* Updated `odoo.conf` to explicitly set `data_dir = /var/lib/odoo` for clarity, reordered and spaced configuration options for better readability, and ensured the admin password is clearly defined.